### PR TITLE
Skip external mounts with disabled previews

### DIFF
--- a/tests/WatcherTest.php
+++ b/tests/WatcherTest.php
@@ -45,7 +45,7 @@ class WatcherTest extends TestCase {
 	/** @var Watcher */
 	private $watcher;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->connection = \OC::$server->getDatabaseConnection();


### PR DESCRIPTION
For external storage mounts one can disable previews:
![setting](https://fb.hash.works/R2qz3/)

This change respects this setting and skips folders with disabled previews:
```
2020-05-04T15:52:15+00:00 Scanning folder /hashworks/files
2020-05-04T15:52:15+00:00 Skipping folder /hashworks/files/NoMedia
2020-05-04T15:52:15+00:00 Scanning folder /hashworks/files/Photos
[...]
2020-05-04T15:52:15+00:00 Skipping folder /hashworks/files/GDrive
```

Resolves #151.