### PR TITLE
Feature: Multiple Options

### DIFF
--- a/lib/Command/DeleteOld.php
+++ b/lib/Command/DeleteOld.php
@@ -64,7 +64,7 @@ class DeleteOld extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$userIds = $input->getArgument('user_id');
 
-		if (count($userId) === 0) {
+		if (count($userIds) === 0) {
 			$this->userManager->callForSeenUsers(function (IUser $user) {
 				$this->deletePreviews($user);
 			});

--- a/lib/Command/DeleteOld.php
+++ b/lib/Command/DeleteOld.php
@@ -56,22 +56,24 @@ class DeleteOld extends Command {
 			->setDescription('Delete old preview folder (pre NC11)')
 			->addArgument(
 				'user_id',
-				InputArgument::OPTIONAL,
-				'Delete old preview folder for the given user'
+				InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
+				'Delete old preview folder for the given user(s)'
 			);
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$userId = $input->getArgument('user_id');
+		$userIds = $input->getArgument('user_id');
 
-		if ($userId === null) {
+		if (count($userId) === 0) {
 			$this->userManager->callForSeenUsers(function (IUser $user) {
 				$this->deletePreviews($user);
 			});
 		} else {
-			$user = $this->userManager->get($userId);
-			if ($user !== null) {
-				$this->deletePreviews($user);
+			foreach ($userIds as $userId) {
+				$user = $this->userManager->get($userId);
+				if ($user !== null) {
+					$this->deletePreviews($user);
+				}
 			}
 		}
 

--- a/lib/Command/Generate.php
+++ b/lib/Command/Generate.php
@@ -85,13 +85,13 @@ class Generate extends Command {
 			->setDescription('Generate previews')
 			->addArgument(
 				'user_id',
-				InputArgument::OPTIONAL,
-				'Generate previews for the given user'
+				InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
+				'Generate previews for the given user(s)'
 			)->addOption(
 				'path',
 				'p',
 				InputOption::VALUE_OPTIONAL,
-				'limit scan to this path, eg. --path="/alice/files/Photos", the user_id is determined by the path and the user_id parameter is ignored'
+				'limit scan to this path, eg. --path="/alice/files/Photos", the user_id is determined by the path and all user_id arguments are ignored'
 			);
 	}
 
@@ -117,15 +117,17 @@ class Generate extends Command {
 				$this->generatePathPreviews($user, $inputPath);
 			}
 		} else {
-			$userId = $input->getArgument('user_id');
-			if ($userId === null) {
+			$userIds = $input->getArgument('user_id');
+			if (count($userId) === 0) {
 				$this->userManager->callForSeenUsers(function (IUser $user) {
 					$this->generateUserPreviews($user);
 				});
 			} else {
-				$user = $this->userManager->get($userId);
-				if ($user !== null) {
-					$this->generateUserPreviews($user);
+				for ($userIds as $userId) {
+					$user = $this->userManager->get($userId);
+					if ($user !== null) {
+						$this->generateUserPreviews($user);
+					}
 				}
 			}
 		}

--- a/lib/Command/Generate.php
+++ b/lib/Command/Generate.php
@@ -120,12 +120,12 @@ class Generate extends Command {
 			}
 		} else {
 			$userIds = $input->getArgument('user_id');
-			if (count($userId) === 0) {
+			if (count($userIds) === 0) {
 				$this->userManager->callForSeenUsers(function (IUser $user) {
 					$this->generateUserPreviews($user);
 				});
 			} else {
-				for ($userIds as $userId) {
+				foreach ($userIds as $userId) {
 					$user = $this->userManager->get($userId);
 					if ($user !== null) {
 						$this->generateUserPreviews($user);

--- a/lib/Command/Generate.php
+++ b/lib/Command/Generate.php
@@ -90,8 +90,8 @@ class Generate extends Command {
 			)->addOption(
 				'path',
 				'p',
-				InputOption::VALUE_OPTIONAL,
-				'limit scan to this path, eg. --path="/alice/files/Photos", the user_id is determined by the path and all user_id arguments are ignored'
+				InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+				'limit scan to this path, eg. --path="/alice/files/Photos", the user_id is determined by the path and all user_id arguments are ignored, multiple usages allowed'
 			);
 	}
 
@@ -108,13 +108,15 @@ class Generate extends Command {
 
 		$this->sizes = SizeHelper::calculateSizes($this->config);
 
-		$inputPath = $input->getOption('path');
-		if ($inputPath) {
-			$inputPath = '/' . trim($inputPath, '/');
-			[, $userId,] = explode('/', $inputPath, 3);
-			$user = $this->userManager->get($userId);
-			if ($user !== null) {
-				$this->generatePathPreviews($user, $inputPath);
+		$inputPaths = $input->getOption('path');
+		if ($inputPaths) {
+			foreach ($inputPaths as $inputPath) {
+				$inputPath = '/' . trim($inputPath, '/');
+				[, $userId,] = explode('/', $inputPath, 3);
+				$user = $this->userManager->get($userId);
+				if ($user !== null) {
+					$this->generatePathPreviews($user, $inputPath);
+				}
 			}
 		} else {
 			$userIds = $input->getArgument('user_id');


### PR DESCRIPTION
This pull request adds the possibility to specify multiple `user_id` arguments and multiple `--path` options in the `:delete_old` and `:generate-all` commands respectively.

It does this by adding the respective [Symfony `::IS_ARRAY`](https://symfony.com/doc/4.4/console/input.html) mode specifiers to the arguments/options, adapting the `if` checks if needed and wrapping the existing code paths inside a `foreach` loop.