### PR TITLE
use {$var} instead of ${var}

### DIFF
--- a/lib/Command/PreGenerate.php
+++ b/lib/Command/PreGenerate.php
@@ -201,7 +201,7 @@ class PreGenerate extends Command {
 				// Maybe log that previews could not be generated?
 			} catch (\InvalidArgumentException $e) {
 				$error = $e->getMessage();
-				$this->output->writeln("<error>${error}</error>");
+				$this->output->writeln("<error>{$error}</error>");
 			}
 		}
 	}


### PR DESCRIPTION
PHP 8.2 complains with

    Using ${var} in strings is deprecated, use {$var} instead