### PR TITLE
chore(release): v5.11.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 -->
 # Changelog
 
+## 5.11.0-beta.1 - 2025-11-08
+### Added
+- Allow running multiple instances of pre-generate
+- Implement spawning multiple workers for generate-all
+
+### Removed
+- Drop support for Nextcloud 28 and 29
+- Drop support for PHP 8.0
+
 ## 5.10.0 - 2025-09-05
 ### Added
 - Support for Nextcloud 32

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@ The first time you install this app, before using a cron job, you properly want 
 
 **Important**: To enable pre-generation of previews you must add **php /var/www/nextcloud/occ preview:pre-generate** to a system cron job that runs at times of your choosing.]]>
 	</description>
-	<version>5.11.0-dev.1</version>
+	<version>5.11.0-beta.1</version>
 	<licence>agpl</licence>
 	<author>Richard Steinmetz</author>
 	<namespace>PreviewGenerator</namespace>


### PR DESCRIPTION
# Changelog

## 5.11.0-beta.1 - 2025-11-08
### Added
- Allow running multiple instances of pre-generate
- Implement spawning multiple workers for generate-all

### Removed
- Drop support for Nextcloud 28 and 29
- Drop support for PHP 8.0