### PR TITLE
[stable5.11] fix: generate-all skipping some files due to negative remainder

### DIFF
--- a/lib/Command/Generate.php
+++ b/lib/Command/Generate.php
@@ -11,6 +11,7 @@ namespace OCA\PreviewGenerator\Command;
 
 use OCA\Files_External\Service\GlobalStoragesService;
 use OCA\PreviewGenerator\Model\WorkerConfig;
+use OCA\PreviewGenerator\Service\ModuloService;
 use OCA\PreviewGenerator\SizeHelper;
 use OCP\Encryption\IManager;
 use OCP\Files\File;
@@ -286,7 +287,7 @@ class Generate extends Command {
 
 		if ($this->workerConfig !== null) {
 			$hash = $this->hashFileId($file->getId());
-			if (($hash % $this->workerConfig->getWorkerCount()) !== $this->workerConfig->getWorkerIndex()) {
+			if (ModuloService::absMod($hash, $this->workerConfig->getWorkerCount()) !== $this->workerConfig->getWorkerIndex()) {
 				return;
 			}
 		}

--- a/lib/Service/ModuloService.php
+++ b/lib/Service/ModuloService.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Richard Steinmetz
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\PreviewGenerator\Service;
+
+final class ModuloService {
+	/**
+	 * Perform the modulo operation ensuring that the remainder is always positive (0 <= remainder
+	 * < $n).
+	 *
+	 * Ref https://stackoverflow.com/a/4409320
+	 */
+	public static function absMod(int $x, int $n): int {
+		$r = $x % $n;
+		if ($r < 0) {
+			$r += abs($n);
+		}
+
+		return $r;
+	}
+}

--- a/tests/Service/Test.php
+++ b/tests/Service/Test.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Richard Steinmetz
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\PreviewGenerator\Tests\Service;
+
+use OCA\PreviewGenerator\Service\ModuloService;
+use PHPUnit\Framework\TestCase;
+
+class Test extends TestCase {
+	public static function moduloDataProvider(): array {
+		return [
+			[3, 10, 3],
+			[-3, 10, 7],
+			[13, 10, 3],
+			[-13, 10, 7],
+		];
+	}
+
+	/** @dataProvider moduloDataProvider */
+	public function testAbsMod(int $x, int $n, int $expected): void {
+		$this->assertEquals($expected, ModuloService::absMod($x, $n));
+	}
+}


### PR DESCRIPTION
Manual backport of #589 