### PR TITLE
[stable5.12] feat: remove support for Nextcloud 34 (unreleased)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -28,7 +28,7 @@ The first time you install this app, before using a cron job, you properly want 
 	<repository type="git">https://github.com/nextcloud/previewgenerator.git</repository>
 	<dependencies>
 		<php min-version="8.1" max-version="8.5" />
-		<nextcloud min-version="30" max-version="34" />
+		<nextcloud min-version="30" max-version="33" />
 	</dependencies>
 	<background-jobs>
 		<job>OCA\PreviewGenerator\BackgroundJob\PreviewJob</job>


### PR DESCRIPTION
Was not supposed to be merged on `stable5.12`. Is not critical as only the beta was released so far.