### PR TITLE
chore(release): v5.12.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 -->
 # Changelog
 
+## 5.12.0-beta.2 - 2026-02-01
+### Removed
+- Remove support for Nextcloud 34 (unreleased)
+
+### Fixed
+- Remove leftover var_dump() debugging call
+- Always return an exit code (preview:pre-generate)
+
 ## 5.12.0-beta.1 - 2026-01-31
 ### Added
 - Add support for Nextcloud 34

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@ The first time you install this app, before using a cron job, you properly want 
 
 The preview queue will be processed automatically by a background job if the system cron background job mode is configured in Nextcloud. Additionally, you may run **occ preview:pre-generate -vvv** to a process the queue of pending previews immediately.]]>
 	</description>
-	<version>5.12.0-beta.1</version>
+	<version>5.12.0-beta.2</version>
 	<licence>agpl</licence>
 	<author>Richard Steinmetz</author>
 	<namespace>PreviewGenerator</namespace>


### PR DESCRIPTION
# Changelog

## 5.12.0-beta.2 - 2026-02-01
### Removed
- Remove support for Nextcloud 34 (unreleased)

### Fixed
- Remove leftover var_dump() debugging call
- Always return an exit code (preview:pre-generate)